### PR TITLE
追加了随机按钮，可以乱序背单词

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -179,7 +179,18 @@ const LeftArrowButton = styled(ArrowButton)`
 // 右箭头按钮
 const RightArrowButton = styled(ArrowButton)`
   position: fixed;
-  bottom: 200px;
+  bottom: 250px;
+  right: 50px;
+  z-index: 10;
+
+  @media (max-width: 768px) {
+    position: static;
+  }
+`
+// 随机按钮
+const RandomArrowButton = styled(ArrowButton)`
+  position: fixed;
+  bottom: 150px;
   right: 50px;
   z-index: 10;
 
@@ -405,6 +416,13 @@ function App() {
           >
             下一个 ➡️
           </RightArrowButton>
+          <RandomArrowButton
+            textColor={bgIndex === 0 ? '#000' : '#fff'}
+            onClick={() => setCurrentIndex(()=> (Math.floor(Math.random() * totalWords) + 1))}
+            disabled={isLoading}
+          >
+            随机 🔀
+          </RandomArrowButton>
         </ArrowContainer>
         <ButtonContainer>
           <FixedSettingsButton


### PR DESCRIPTION
对于背单词来说，有时候打乱单词出现的顺序效果可能更好，追加了一个随机按钮，除了【下一个】，【下一个】以外，还可以点击【随机】按钮，随意跳到另一个单词。显示格式未做调整